### PR TITLE
fix (composer) build: fixes symfony-cmd: command not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,9 @@
     "preferred-install": {
       "*": "dist"
     },
+    "allow-plugins": {
+      "symfony/flex": true
+    },
     "sort-packages": true
   },
   "autoload": {
@@ -99,7 +102,7 @@
     ],
     "post-update-cmd": [
       "@auto-scripts"
-    ] 
+    ]
   },
   "conflict": {
     "symfony/symfony": "*"


### PR DESCRIPTION
# what
composer install is failing and therefor the docker build because of the new security feature of composer.
this PR fixes this