### PR TITLE
API groups to teams mapper

### DIFF
--- a/.env
+++ b/.env
@@ -76,3 +76,9 @@ APP_DEMO=0
 ###> LaF ###
 laF_version=2.0.0-dev
 ###< LaF ###
+
+### Group Mapper API ###
+GROUP_API_URI=http://localhost
+GROUP_API_KEY=CHANGEME
+GROUP_API_ROLE=CHANGEME
+GROUP_API_USER_ID=CHANGEME

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ docker.conf
 ###> phpstan/phpstan ###
 phpstan.neon
 ###< phpstan/phpstan ###
+
+.php-version

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -11,6 +11,13 @@ framework:
         cookie_secure: auto
         cookie_samesite: lax
 
+    http_client:
+        scoped_clients:
+            group.client:
+                base_uri: '%env(GROUP_API_URI)%'
+                headers:
+                    'X-API-KEY': '%env(default::GROUP_API_KEY)%'
+
     #esi: true
     #fragments: true
     php_errors:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -15,6 +15,8 @@ parameters:
     KEYCLOAK_SECRET: '%env(OAUTH_KEYCLOAK_CLIENT_SECRET)%'
     KEYCLOAK_ID: '%env(OAUTH_KEYCLOAK_CLIENT_ID)%'
     superAdminRole: '%env(superAdminRole)%'
+    group_api_user_id: '%env(default::GROUP_API_USER_ID)%'
+    group_api_role: '%env(default::GROUP_API_ROLE)%'
 services:
     # default configuration for services in *this* file
     _defaults:
@@ -57,3 +59,8 @@ services:
                connection: default
         calls:
             - [ setAnnotationReader, [ "@annotation_reader" ] ]
+
+    App\Security\KeycloakAuthenticator:
+        arguments:
+            $groupApiUserId: '%group_api_user_id%'
+            $groupApiRole: '%group_api_role%'

--- a/src/Controller/SettingsController.php
+++ b/src/Controller/SettingsController.php
@@ -43,8 +43,7 @@ class SettingsController extends BaseController
         $errors = array();
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $newSettings = $form->getData();
-            $settings->setUseKeycloakGroups($newSettings->getUseKeycloakGroups());
+            $settings = $form->getData();
             $errors = $validator->validate($settings);
             if (count($errors) == 0) {
                 $em->persist($settings);

--- a/src/Controller/TeamController.php
+++ b/src/Controller/TeamController.php
@@ -348,15 +348,14 @@ class TeamController extends BaseController
 
         $availableTeams = $currentTeamService->getTeamsWithoutCurrentHierarchy($user, $team);
 
-        $form = $this->createForm(
-            TeamType::class,
-            $team,
-            ['teams' => $availableTeams,]
-        );
+        $form = $this->createForm(TeamType::class, $team, [
+            'teams' => $availableTeams,
+            'disabled' => $team->isImmutable(),
+        ]);
         $form->handleRequest($request);
 
         $errors = array();
-        if ($form->isSubmitted() && $form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid() && !$team->isImmutable()) {
             $nTeam = $form->getData();
             $errors = $validator->validate($nTeam);
             if (count($errors) == 0) {
@@ -391,7 +390,7 @@ class TeamController extends BaseController
     {
         $user = $this->getUser();
         $settings = $settingsRepository->findOne();
-        $useKeycloakGroups = $settings ? $settings->getUseKeycloakGroups() : false;
+        $useKeycloakGroups = $settings && $settings->getUseKeycloakGroups();
 
         if (!$securityService->superAdminCheck($user)) {
             return $this->redirectToRoute('dashboard');
@@ -440,7 +439,7 @@ class TeamController extends BaseController
         $teamId = $request->get('id');
         $team = $teamId ? $teamRepository->find($teamId) : $currentTeamService->getCurrentAdminTeam($user);
 
-        if ($securityService->superAdminCheck($user) === false) {
+        if ($securityService->superAdminCheck($user) === false || $team->isImmutable()) {
             return $this->redirectToRoute('dashboard');
         }
 

--- a/src/Controller/TeamMemberController.php
+++ b/src/Controller/TeamMemberController.php
@@ -198,7 +198,7 @@ class TeamMemberController extends BaseController
         $teamId = $request->get('id');
         $currentTeam = null;
         $settings = $settingsRepository->findOne();
-        $useKeycloakGroups = $settings ? $settings->getUseKeycloakGroups() : false;
+        $useKeycloakGroups = $settings && $settings->getUseKeycloakGroups();
         $this->setBackButton($this->generateUrl('manage_teams'));
 
         if ($teamId) {

--- a/src/Entity/Settings.php
+++ b/src/Entity/Settings.php
@@ -3,31 +3,47 @@
 namespace App\Entity;
 
 use App\Repository\SettingsRepository;
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: SettingsRepository::class)]
 class Settings
 {
+    const NO_GROUP_MAPPING = 0;
+
+    const KEYCLOAK_GROUP_MAPPING = 1;
+
+    const API_GROUP_MAPPING = 2;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
     private $id;
 
-    #[ORM\Column(type: 'boolean', nullable: true)]
-    private $useKeycloakGroups;
+    #[ORM\Column(options: [
+        'default' => 0,
+    ])]
+    #[Assert\Choice([
+        self::NO_GROUP_MAPPING,
+        self::KEYCLOAK_GROUP_MAPPING,
+        self::API_GROUP_MAPPING,
+    ])]
+    private int $groupMapping = 0;
 
-    public function getUseKeycloakGroups(): ?bool
+    public function getGroupMapping(): int
     {
-        return $this->useKeycloakGroups;
+        return $this->groupMapping;
     }
 
-    public function setUseKeycloakGroups(?bool $useKeycloakGroups): self
+    public function setGroupMapping(int $groupMapping): static
     {
-        $this->useKeycloakGroups = $useKeycloakGroups;
+        $this->groupMapping = $groupMapping;
 
         return $this;
+    }
+
+    public function getUseKeycloakGroups(): bool
+    {
+        return $this->groupMapping === self::KEYCLOAK_GROUP_MAPPING;
     }
 }

--- a/src/Entity/Team.php
+++ b/src/Entity/Team.php
@@ -13,7 +13,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
-use phpDocumentor\Reflection\Types\Boolean;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
 use Gedmo\Mapping\Annotation as Gedmo;
@@ -232,6 +231,11 @@ class Team
 
     #[ORM\ManyToMany(targetEntity: AuditTomZiele::class, mappedBy: 'ignoredInTeams')]
     private $ignoredAuditGoals;
+
+    #[ORM\Column(options: [
+        'default' => 0,
+    ])]
+    private bool $immutable = false;
 
     public function __construct()
     {
@@ -1393,9 +1397,11 @@ class Team
         return $this->root;
     }
 
-    public function setParent(self $parent = null): void
+    public function setParent(self $parent = null): static
     {
         $this->parent = $parent;
+
+        return $this;
     }
 
     public function getParent(): ?self
@@ -1656,6 +1662,18 @@ class Team
             $this->ignoredProducts->removeElement($product);
             $product->removeIgnoredInTeam($this);
         }
+
+        return $this;
+    }
+
+    public function isImmutable(): bool
+    {
+        return $this->immutable;
+    }
+
+    public function setImmutable(bool $immutable): static
+    {
+        $this->immutable = $immutable;
 
         return $this;
     }

--- a/src/Entity/Team.php
+++ b/src/Entity/Team.php
@@ -20,6 +20,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 #[Gedmo\Tree(type: 'nested')]
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
 #[UniqueEntity('slug')]
+#[ORM\UniqueConstraint(name: 'UNQ_team_name_and_immutable', columns: ['name', 'immutable'])]
 class Team
 {
     #[ORM\Id]
@@ -27,7 +28,7 @@ class Team
     #[ORM\Column(type: 'integer')]
     private $id;
 
-    #[ORM\Column(type: 'string', length: 255, unique: true)]
+    #[ORM\Column(type: 'string', length: 255)]
     #[Assert\NotBlank]
     private $name;
 

--- a/src/Form/Type/SettingsType.php
+++ b/src/Form/Type/SettingsType.php
@@ -8,18 +8,10 @@
 
 namespace App\Form\Type;
 
-use App\Entity\AuditTom;
-use App\Entity\AuditTomAbteilung;
-use App\Entity\AuditTomStatus;
-use App\Entity\AuditTomZiele;
 use App\Entity\Settings;
-use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -28,8 +20,22 @@ class SettingsType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('useKeycloakGroups', CheckboxType::class, ['label' => 'useKeycloakGroups', 'help'=> 'useKeycloakGroupsHelp', 'required' => false, 'translation_domain' => 'form'])
-            ->add('save', SubmitType::class, ['attr' => array('class' => 'btn'),'label' => 'save', 'translation_domain' => 'form']);
+            ->add('groupMapping', ChoiceType::class, [
+                'label' => 'groupMapping',
+                'help'=> 'groupMappingHelp',
+                'translation_domain' => 'form',
+                'expanded' => true,
+                'choices' => [
+                    'noGroupMapping' => Settings::NO_GROUP_MAPPING,
+                    'useKeycloakGroups' => Settings::KEYCLOAK_GROUP_MAPPING,
+                    'useApiGroups' => Settings::API_GROUP_MAPPING,
+                ]
+            ])
+            ->add('save', SubmitType::class, [
+                'attr' => array('class' => 'btn'),
+                'label' => 'save',
+                'translation_domain' => 'form'
+            ]);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Migrations/Version20240807153157.php
+++ b/src/Migrations/Version20240807153157.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240807153157 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add API group mapping option';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE settings ADD group_mapping INT DEFAULT 0 NOT NULL');
+        $this->addSql('UPDATE settings SET group_mapping = use_keycloak_groups WHERE use_keycloak_groups IS NOT NULL');
+        $this->addSql('ALTER TABLE settings DROP use_keycloak_groups');
+        $this->addSql('ALTER TABLE team ADD immutable TINYINT(1) DEFAULT 0 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE settings ADD use_keycloak_groups TINYINT(1) DEFAULT NULL');
+        $this->addSql('UPDATE settings SET use_keycloak_groups = group_mapping WHERE group_mapping = 1');
+        $this->addSql('ALTER TABLE settings DROP group_mapping');
+        $this->addSql('ALTER TABLE team DROP immutable');
+    }
+}

--- a/src/Migrations/Version20240816105509.php
+++ b/src/Migrations/Version20240816105509.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240816105509 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Avoid name conflicts for API generated teams by modifying the team unique constraint';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX UNQ_team_name ON team');
+        $this->addSql('CREATE UNIQUE INDEX UNQ_team_name_and_immutable ON team (name, immutable)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX UNQ_team_name_and_immutable ON team');
+        $this->addSql('CREATE UNIQUE INDEX UNQ_team_name ON team (name)');
+    }
+}

--- a/src/Security/KeycloakAuthenticator.php
+++ b/src/Security/KeycloakAuthenticator.php
@@ -3,10 +3,13 @@
 namespace App\Security;
 
 use App\Entity\Settings;
+use App\Entity\Team;
 use App\Entity\User;
 use App\Repository\TeamRepository;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\EntityManagerInterface;
+use Exception;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
@@ -24,12 +27,15 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\Util\TargetPathTrait;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class KeycloakAuthenticator extends OAuth2Authenticator implements AuthenticationEntryPointInterface
 {
     use TargetPathTrait;
 
     public function __construct(
+        private readonly ?string                $groupApiUserId,
+        private readonly ?string                $groupApiRole,
         private readonly LoggerInterface        $logger,
         private readonly ParameterBagInterface  $parameterBag,
         private readonly TokenStorageInterface  $tokenStorage,
@@ -37,6 +43,7 @@ class KeycloakAuthenticator extends OAuth2Authenticator implements Authenticatio
         private readonly EntityManagerInterface $em,
         private readonly RouterInterface        $router,
         private readonly TeamRepository         $teamRepository,
+        private readonly HttpClientInterface    $groupClient,
     )
     {
     }
@@ -125,10 +132,10 @@ class KeycloakAuthenticator extends OAuth2Authenticator implements Authenticatio
         try {
             // FIXME: ResourceOwnerInterface cannot have method getEmail()
             return $keycloakUser->getEmail();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             try {
                 return $keycloakUser->toArray()['preferred_username'];
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
             }
         }
 
@@ -188,12 +195,109 @@ class KeycloakAuthenticator extends OAuth2Authenticator implements Authenticatio
         $user->setRoles(roles: $this->getRolesForKeycloakUser(keycloakUser: $keycloakUser));
 
         $settings = $this->em->getRepository(Settings::class)->findOne();
-        if ($settings && $settings->getUseKeycloakGroups()) {
-            $user->setTeams(teams: $this->getTeamsFromKeycloakGroups(keycloakUser: $keycloakUser));
+        if ($settings) {
+            switch ($settings->getGroupMapping()) {
+                case Settings::KEYCLOAK_GROUP_MAPPING:
+                    $user->setTeams(teams: $this->getTeamsFromKeycloakGroups(keycloakUser: $keycloakUser));
+                    break;
+                case Settings::API_GROUP_MAPPING:
+                    $teams = $this->syncApiGroups($keycloakUser);
+                    foreach ($teams as $team) {
+                        $user->addTeam($team);
+                    }
+                    break;
+            }
         }
 
         $this->em->persist($user);
         $this->em->flush();
         return $user;
+    }
+
+    private function syncApiGroups(ResourceOwnerInterface $keycloakUser): Collection {
+        try {
+            $userId = $keycloakUser->toArray()[$this->groupApiUserId];
+            $response = $this->groupClient->request('GET', "/v1/users/$userId/rbac-structure");
+            $responsePayload = $response->toArray();
+
+            $groups = array_combine(
+                array_column($responsePayload['groups'], 'divisionKey'),
+                $responsePayload['groups']
+            );
+
+            $roleDivisions = $this->getGroupsOfMatchingRoles($responsePayload['roles']);
+            $roleGroups = array_filter($groups, function ($groupKey) use ($roleDivisions) {
+                return in_array($groupKey, $roleDivisions);
+            }, ARRAY_FILTER_USE_KEY);
+
+            return $this->createTeams($roleGroups, $groups);
+        } catch (\Throwable $e) {
+            $this->logger->error("Exception \"{$e->getMessage()}\" at {$e->getFile()} line {$e->getLine()}");
+            return new ArrayCollection();
+        }
+    }
+
+    private function getGroupsOfMatchingRoles(array $roles) {
+        $teamAdminRoles = array_filter($roles, function ($role) {
+            return $role['id'] === $this->groupApiRole;
+        });
+
+        return array_map(function ($role) {
+            return $role['divisionKey'];
+        }, $teamAdminRoles);
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function createTeams(array $userGroups, array $groupsTree): Collection {
+        $teams = [];
+        foreach ($userGroups as $group) {
+            $teams[] = $this->createTeamHierarchy($group, $groupsTree);
+        }
+        return new ArrayCollection($teams);
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function createTeamHierarchy(array $group, array $groupsTree): ?Team {
+        if (!array_key_exists('parentKey', $group)) {
+            throw new Exception('Invalid group: '.implode(',', $group));
+        }
+
+        if (!$group['parentKey']) {
+            return $this->getTeam($group);
+        }
+
+        if (!array_key_exists($group['parentKey'], $groupsTree)) {
+            throw new Exception('Missing group in tree: '.implode(',', $group));
+        }
+
+        $parent = $this->createTeamHierarchy($groupsTree[$group['parentKey']], $groupsTree);
+
+        return $this->getTeam($group, $parent);
+    }
+
+    private function getTeam(array $group, Team $parent = null): Team {
+        $team = $this->teamRepository->findOneBy([
+            'immutable' => 1,
+            'name' => $group['displayName'],
+        ]);
+
+        if (!$team) {
+            $team = new Team();
+            $team->setName($group['displayName'])
+                ->setImmutable(true)
+                ->setParent($parent)
+                ->setActiv(true)
+                ->setStrasse('')
+                ->setPlz('')
+                ->setStadt('')
+                ->setCeo('');
+            $this->em->persist($team);
+        }
+
+        return $team;
     }
 }

--- a/templates/settings/settings.html.twig
+++ b/templates/settings/settings.html.twig
@@ -10,6 +10,15 @@
 
 {% block body %}
     {{ form_start(form) }}
-    {{ form_row(form) }}
+    <fieldset class="form-row">
+        {{ form_label(form.groupMapping) }}
+        {% for choice in form.groupMapping %}
+            {{ form_widget(choice) }}
+            {{ form_label(choice, '', {
+                'label_attr': {'style': 'display: inline-block;'}
+            }) }}
+            <div class="help-text" style="margin-bottom: 0.75rem; margin-top: 0;">{{ (choice.vars.label~'Help')|trans({}, 'form') }}</div>
+        {% endfor %}
+    </fieldset>
     {{ form_end(form) }}
 {% endblock %}

--- a/translations/form.de.yaml
+++ b/translations/form.de.yaml
@@ -16,8 +16,13 @@ send: Senden
 appoint: Ernennen
 
 # settings
+groupMapping: Gruppenübertragung
+noGroupMapping: Keine Übertragung von Gruppen
+noGroupMappingHelp: Die Teamzuweisung soll nur über das ODC gesteuert werden.
 useKeycloakGroups: Keycloak Gruppen verwenden
 useKeycloakGroupsHelp: Wenn diese Option aktiviert ist, erfolgt die Teamzuweisung im Keycloak und nicht im ODC. Damit das richtig funktioniert, muss im Keycloak Client ein Mapper namens 'groups' existieren, bei dem die Option 'Full group path' deaktiviert ist.
+useApiGroups: Gruppen von API übernehmen
+useApiGroupsHelp: Die Teamzuweisung erfolgt über eine externe API.
 
 # status
 status: Status


### PR DESCRIPTION
Fügt eine neue Option zum Übertragen von API Gruppen zu Teams in den ODC Adminbereich hinzu:
- Konfiguration der API (baseURI, API-Key, etc.) wird über Umgebungsvariablen gesetzt.
- Als Alternative zum bisherigen Keycloak Group Mapper gedacht, bei dem die Gruppen  aus den OIDC Resource Owner Details bezogen werden und damit von Keycloak selbst kommen. Aber wir hatten auch mit @holema überlegt beide Optionen zusammenzulegen, richtig?
- Gruppen werden beim Anmelden erzeugt. Sie sind unveränderbar, können also nicht bearbeitet werden.
- Teammitgliedschaft wird auf Basis der API Gruppen zugewiesen aber nicht entzogen.
- Wenn ein Fehler auftritt, dann klappt der Login, aber alle Teammitgliedschaften bleiben unverändert.

![image](https://github.com/user-attachments/assets/8a1cc4fa-5687-4b02-b37e-4b6256a0fd5c)

@holema Wir hatten ja über die Namenskonflikte gesprochen. Ich habe dafür zunächst eine einfache Lösung in der Datenbank eingebaut, sodass API Teams quasi ihren eigenen Namespace bekommen: 35ad378
Siehst du damit ein Problem?

Offene Punkte:
Das Entziehen von Gruppenmitgliedschaften wird noch nicht unterstützt. Der Grund ist, dass wenn Mitgliedschaften durch die API auch entzogen werden, dass dann das Formular bei `/team_mitglieder` keinen Sinn mehr macht. ODC definierte Mitgliedschaften würden bei jedem Login überschrieben werden.

Bevor wir das Entfernen von Team-Mitgliedern unterstützen, sollte wir folgende Frage beantworten:
Soll es weiter möglich sein im ODC Teams zuweisen? Falls nicht, dann sollte das Team-Mitglieder Formular deaktiviert werden.
Falls manuelles Zuwesien im ODC weiter möglich sein sollte wird es etwas schwieriger.
@georgloesel Hier würden wir auch von dir Feedback brauchen.